### PR TITLE
STYLE: Conform to `CMake` style.

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,15 +1,14 @@
-
 # the top-level README is used for describing this module, just
 # re-used it for documentation here
-get_filename_component( MY_CURENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-file( READ "${MY_CURENT_DIR}/README" DOCUMENTATION )
+get_filename_component(MY_CURENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURENT_DIR}/README" DOCUMENTATION)
 
 
 # The testing module depends on ITKTestKernel)
  
 # define the dependencies of the include module and the tests
 itk_module(RobustPredicate
-DEPENDS
+  DEPENDS
   TEST_DEPENDS
     ITKTestKernel
   EXCLUDE_FROM_DEFAULT


### PR DESCRIPTION
Conform to `CMake` style:
- Remove unnecessary white space at the beginning.
- Remove `CMake` white spaces before/after `CMake` arguments in `itk-module.cmake`.