### PR TITLE
DOC: Fix `README.rst` file format.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,11 @@ ITKRobustPredicate
 .. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/ITKRobustPredicate.svg?style=shield
     :target: https://circleci.com/gh/InsightSoftwareConsortium/ITKRobustPredicate
 
-===========
-   Linux   
-===========
-|CircleCI| 
-===========
+=========== =
+   Linux
+=========== =
+|CircleCI|
+=========== =
 
 
 Overview


### PR DESCRIPTION
Fix the `README.rst` file format: the CI badge table not being correctly
built made the file not to be parsed as reSTructuredText syntax by GitHub.