### PR TITLE
BUG: Fix link libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.9)
 project(RobustPredicate)
-set(RobustPredicate_LIBRARIES RobustPredicate)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,10 @@
-set(RobustPredicate_SRC
+set(${itk-module}_SRC
 predicates.c
 )
 
 add_library(${itk-module} ${${itk-module}_SRC})
 
-target_link_libraries(${itk-module}  ${${itk-module}_LIBRARIES})
+target_link_libraries(${itk-module} ${ITK_LIBRARIES})
 
 itk_module_target(${itk-module})
 

--- a/test/predicates_test.cxx
+++ b/test/predicates_test.cxx
@@ -1,6 +1,5 @@
-extern "C"{
 #include "predicates.h"
-}
+
 
 int test( double eps_x, double eps_y, int exact )
 {


### PR DESCRIPTION
Fix link libraries: remove the variable that made the module being linked
to itself and make it link to ITK libraries.

The module does not depend on external libraries.